### PR TITLE
show warning messages when reading malformed HTML

### DIFF
--- a/src/EzXML.jl
+++ b/src/EzXML.jl
@@ -107,7 +107,7 @@ else
     const libxml2 = "libxml2"
 end
 
-import Compat: @compat
+import Compat: @compat, take!
 
 include("error.jl")
 include("node.jl")

--- a/src/document.jl
+++ b/src/document.jl
@@ -181,6 +181,7 @@ function readhtml(filename::AbstractString)
         Ptr{_Node},
         (Cstring, Cstring, Cint),
         filename, encoding, options) != C_NULL
+    show_warnings()
     return Document(doc_ptr)
 end
 
@@ -201,6 +202,7 @@ function readhtml(input::IO)
         Ptr{_Node},
         (Ptr{Void}, Ptr{Void}, Ptr{Void}, Cstring, Cstring, Cint),
         readcb, closecb, context, uri, encoding, options) != C_NULL
+    show_warnings()
     return Document(doc_ptr)
 end
 


### PR DESCRIPTION
This is an ad-hoc fix not to accumulate recoverable errors.

This will fix a problem reported by @yuifu in person.