### PR TITLE
Update deprecated tuple type call's in cfunction

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -220,7 +220,7 @@ end
 function make_read_callback()
     # Passing an input stream as an argument is impossible to create a callback
     # because Julia does not support C-callable closures yet.
-    return cfunction(Cint, (Ptr{Void}, Ptr{UInt8}, Cint)) do context, buffer, len
+    return cfunction(Cint, Tuple{Ptr{Void}, Ptr{UInt8}, Cint}) do context, buffer, len
         input = unsafe_pointer_to_objref(context)
         avail = min(nb_available(input), len)
         if avail > 0

--- a/src/error.jl
+++ b/src/error.jl
@@ -57,7 +57,7 @@ end
 
 # Initialize an error handler.
 function init_error_handler()
-    error_handler = cfunction(Void, (Ptr{Void}, Ptr{Void})) do ctx, err_ptr
+    error_handler = cfunction(Void, Tuple{Ptr{Void}, Ptr{Void}}) do ctx, err_ptr
         if ctx == pointer_from_objref(_Error)
             err = unsafe_load(convert(Ptr{_Error}, err_ptr))
             push!(XML_GLOBAL_ERROR_STACK, XMLError(err.domain, err.code, chomp(unsafe_string(err.message)), err.level, err.line))


### PR DESCRIPTION
The old deprecated form has a performance hit 