### PR TITLE
Add Attribute Functions for the SteamReader

### DIFF
--- a/src/EzXML.jl
+++ b/src/EzXML.jl
@@ -96,7 +96,12 @@ export
     readdtd,
     validate,
     nodedepth,
-    expandtree
+    expandtree,
+    hasnodevalue,
+    nodevalue,
+    hasnodeattributes,
+    nodeattributes,
+    nodeattributecount
 
 using Libdl
 using Printf: @printf

--- a/src/EzXML.jl
+++ b/src/EzXML.jl
@@ -100,8 +100,7 @@ export
     hasnodevalue,
     nodevalue,
     hasnodeattributes,
-    nodeattributes,
-    nodeattributecount
+    nodeattributes
 
 using Libdl
 using Printf: @printf

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -386,6 +386,7 @@ function hasnodeattributes(reader::StreamReader)
        Cint,
        (Ptr{Cvoid},),
        reader.ptr)
+    @assert r >= 0 "XML Error Detected"
     return r == 1
 end
 

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -43,6 +43,7 @@ else
     @assert false "invalid Cint size"
 end
 
+
 function ReaderType(x::Integer)
     return convert(ReaderType, x)
 end
@@ -54,6 +55,8 @@ end
 function Base.convert(::Type{T}, x::ReaderType) where {T<:Integer}
     return convert(T, reinterpret(Cint, x))
 end
+
+Base.hash(x::ReaderType) = hash(convert(Cint,x))
 
 function Base.convert(::Type{ReaderType}, x::ReaderType)
     return x

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -43,7 +43,6 @@ else
     @assert false "invalid Cint size"
 end
 
-
 function ReaderType(x::Integer)
     return convert(ReaderType, x)
 end
@@ -56,7 +55,7 @@ function Base.convert(::Type{T}, x::ReaderType) where {T<:Integer}
     return convert(T, reinterpret(Cint, x))
 end
 
-Base.hash(x::ReaderType) = hash(convert(Cint,x))
+Base.hash(x::ReaderType, h::UInt) = hash(convert(Cint,x), h)
 
 function Base.convert(::Type{ReaderType}, x::ReaderType)
     return x

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -418,11 +418,12 @@ function Base.iterate(attrs::AttributeReader, state = nothing)
     if r == 1
         return (attrs.reader, nothing)
     else
-        ccall(
-        (:xmlTextReaderMoveToElement, EzXML.libxml2),
-        Cint,
-        (Ptr{Cvoid},),
-        attrs.reader.ptr)
+        r = ccall(
+            (:xmlTextReaderMoveToElement, EzXML.libxml2),
+            Cint,
+            (Ptr{Cvoid},),
+            attrs.reader.ptr)
+        @assert r == 1
         return nothing
     end
 end

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -393,7 +393,7 @@ end
 mutable struct AttributeReader
     reader::StreamReader
 
-    function AttributeReader(reader::EzXML.StreamReader)
+    function AttributeReader(reader::StreamReader)
         if nodetype(reader) != READER_ELEMENT
             throw(ArgumentError("Reader not an Element Node"))
         end
@@ -411,7 +411,7 @@ end
 
 function Base.iterate(attrs::AttributeReader, state = nothing)
     r = ccall(
-        (:xmlTextReaderMoveToNextAttribute, EzXML.libxml2),
+        (:xmlTextReaderMoveToNextAttribute, libxml2),
         Cint,
         (Ptr{Cvoid},),
         attrs.reader.ptr)
@@ -420,7 +420,7 @@ function Base.iterate(attrs::AttributeReader, state = nothing)
     else
         if nodetype(attrs.reader) == READER_ATTRIBUTE
             r = ccall(
-                (:xmlTextReaderMoveToElement, EzXML.libxml2),
+                (:xmlTextReaderMoveToElement, libxml2),
                 Cint,
                 (Ptr{Cvoid},),
                 attrs.reader.ptr)
@@ -444,7 +444,7 @@ Return the number of attributes in the current node of `reader`.
 """
 function countattributes(reader::StreamReader)
     r = ccall(
-        (:xmlTextReaderAttributeCount, EzXML.libxml2),
+        (:xmlTextReaderAttributeCount, libxml2),
         Cint,
         (Ptr{Cvoid},),
         reader.ptr)

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -368,7 +368,7 @@ function nodevalue(reader::StreamReader)
         (Ptr{Cvoid},),
         reader.ptr)
     if value_ptr == C_NULL
-        return nothing
+        throw(ArgumentError("Node does not have a value"))
     else
         return unsafe_string(value_ptr)
     end

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -264,6 +264,9 @@ end
 Return if the current node of `reader` has content.
 """
 function hasnodecontent(reader::StreamReader)
+    if nodetype(reader) == READER_ATTRIBUTE
+        return false
+    end
     # TODO: this allocates memory; any way to avoid it?
     ptr = ccall(
         (:xmlTextReaderReadString, libxml2),
@@ -282,10 +285,11 @@ end
     nodecontent(reader::StreamReader)
 
 Return the content of the current node of `reader`.
-
-Note: Nodes of `READER_ATTRIBUTE` will crash with `nodecontent`, use `nodevalue` instead.
 """
 function nodecontent(reader::StreamReader)
+    if nodetype(reader) == READER_ATTRIBUTE
+        throw(ArgumentError("no content"))
+    end
     content_ptr = ccall(
         (:xmlTextReaderReadString, libxml2),
         Cstring,

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -460,7 +460,7 @@ function nodeattributes(reader::StreamReader)
     return attrs
 end
 
-function _getattr(reader::StreamReader, name::AbstractString)
+function attribute_ptr(reader::StreamReader, name::AbstractString)
     value_ptr = ccall(
         (:xmlTextReaderGetAttribute, libxml2),
         Cstring,
@@ -468,7 +468,7 @@ function _getattr(reader::StreamReader, name::AbstractString)
         reader.ptr, name)
 end
 
-function _getattr(reader::StreamReader, no::Integer)
+function attribute_ptr(reader::StreamReader, no::Integer)
     value_ptr = ccall(
         (:xmlTextReaderGetAttributeNo, libxml2),
         Cstring,
@@ -482,7 +482,7 @@ end
 Check if current node of `reader` has attribute `key`.
 """
 function Base.haskey(reader::StreamReader, key::Union{Integer,AbstractString})
-    value_ptr = _getattr(reader,key)
+    value_ptr = attribute_ptr(reader,key)
     ret = value_ptr != C_NULL
     Libc.free(value_ptr)
     return ret
@@ -494,7 +494,7 @@ end
 Get attribute `key` at current node of `reader`.
 """
 function Base.getindex(reader::StreamReader, key::Union{Integer,AbstractString})
-    value_ptr = _getattr(reader,key)
+    value_ptr = attribute_ptr(reader,key)
     if value_ptr == C_NULL
         throw(KeyError(key))
     end

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -391,18 +391,18 @@ function hasnodeattributes(reader::StreamReader)
 end
 
 mutable struct AttributeReader
-    reader::EzXML.StreamReader
+    reader::StreamReader
 
     function AttributeReader(reader::EzXML.StreamReader)
         if nodetype(reader) != READER_ELEMENT
-            throw(InvalidStateException("Reader not an Element",convert(Symbol,nodetype(reader))))
+            throw(ArgumentError("Reader not an Element Node"))
         end
         return new(reader)
     end
 end
 
 function Base.eltype(::Type{AttributeReader})
-    return AttributeReader
+    return StreamReader
 end
 
 function Base.IteratorSize(::Type{AttributeReader})

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -321,6 +321,8 @@ end
     nodecontent(reader::StreamReader)
 
 Return the content of the current node of `reader`.
+
+Note: Nodes of `READER_ATTRIBUTE` will crash with `nodecontent`, use `nodevalue` instead.
 """
 function nodecontent(reader::StreamReader)
     content_ptr = ccall(
@@ -336,6 +338,11 @@ function nodecontent(reader::StreamReader)
     return content
 end
 
+"""
+    hasnodevalue(reader::StreamReader)
+
+Return if the current node of `reader` has a value.
+"""
 function hasnodevalue(reader::StreamReader)
     r = ccall(
        (:xmlTextReaderHasValue, libxml2),
@@ -345,6 +352,13 @@ function hasnodevalue(reader::StreamReader)
     return r == 1
 end
 
+"""
+    nodevalue(reader::StreamReader)
+
+Return the value of the current node of `reader`.
+
+This can be different from `nodecontent`.
+"""
 function nodevalue(reader::StreamReader)
     value_ptr = ccall(
         (:xmlTextReaderConstValue, libxml2),
@@ -358,6 +372,12 @@ function nodevalue(reader::StreamReader)
     end
 end
 
+
+"""
+    hasnodeattributes(reader::StreamReader)
+
+Return if the current node of 'reader' has attributes
+"""
 function hasnodeattributes(reader::StreamReader)
     r = ccall(
        (:xmlTextReaderHasAttributes, libxml2),
@@ -378,6 +398,14 @@ mutable struct AttributeReader
     end
 end
 
+function Base.eltype(::Type{AttributeReader})
+    return AttributeReader
+end
+
+function Base.IteratorSize(::Type{AttributeReader})
+    return Base.SizeUnknown()
+end
+
 function Base.iterate(attrs::AttributeReader, state = nothing)
     r = ccall(
         (:xmlTextReaderMoveToNextAttribute, EzXML.libxml2),
@@ -396,8 +424,18 @@ function Base.iterate(attrs::AttributeReader, state = nothing)
     end
 end
 
+"""
+    nodeattributecount(reader::StreamReader)
+
+Return a AttributeReader for the current node of `reader`
+"""
 eachattribute(reader::StreamReader) = AttributeReader(reader)
 
+"""
+    nodeattributecount(reader::StreamReader)
+
+Return the number of attributes in the current node of `reader`.
+"""
 function nodeattributecount(reader::StreamReader)
     r = ccall(
         (:xmlTextReaderAttributeCount, EzXML.libxml2),
@@ -407,6 +445,11 @@ function nodeattributecount(reader::StreamReader)
     return Int(r)
 end
 
+"""
+    nodeattributes(reader::StreamReader)
+
+Return a dictionary of the attributes in the current node of `reader`.
+"""
 function nodeattributes(reader::StreamReader)
     attrs = Dict{String,String}()
     for attr in eachattribute(reader)

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -84,47 +84,6 @@ const READER_END_ELEMENT            = ReaderType(15)
 const READER_END_ENTITY             = ReaderType(16)
 const READER_XML_DECLARATION        = ReaderType(17)
 
-function Base.convert(::Type{Symbol},x::ReaderType)
-    if x == READER_NONE
-        return :READER_NONE
-    elseif x == READER_ELEMENT
-        return :READER_ELEMENT
-    elseif x == READER_ATTRIBUTE
-        return :READER_ATTRIBUTE
-    elseif x == READER_TEXT
-        return :READER_TEXT
-    elseif x == READER_CDATA
-        return :READER_CDATA
-    elseif x == READER_ENTITY_REFERENCE
-        return :READER_ENTITY_REFERENCE
-    elseif x == READER_ENTITY
-        return :READER_ENTITY
-    elseif x == READER_PROCESSING_INSTRUCTION
-        return :READER_PROCESSING_INSTRUCTION
-    elseif x == READER_COMMENT
-        return :READER_COMMENT
-    elseif x == READER_DOCUMENT
-        return :READER_DOCUMENT
-    elseif x == READER_DOCUMENT_TYPE
-        return :READER_DOCUMENT_TYPE
-    elseif x == READER_DOCUMENT_FRAGMENT
-        return :READER_DOCUMENT_FRAGMENT
-    elseif x == READER_NOTATION
-        return :READER_NOTATION
-    elseif x == READER_WHITESPACE
-        return :READER_WHITESPACE
-    elseif x == READER_SIGNIFICANT_WHITESPACE
-        return :READER_SIGNIFICANT_WHITESPACE
-    elseif x == READER_END_ELEMENT
-        return :READER_END_ELEMENT
-    elseif x == READER_END_ENTITY
-        return :READER_END_ENTITY
-    elseif x == READER_XML_DECLARATION
-        return :READER_XML_DECLARATION
-    else
-        @assert false "unknown reader type"
-    end
-end
 
 function Base.show(io::IO, x::ReaderType)
     if x == READER_NONE

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -418,12 +418,14 @@ function Base.iterate(attrs::AttributeReader, state = nothing)
     if r == 1
         return (attrs.reader, nothing)
     else
-        r = ccall(
-            (:xmlTextReaderMoveToElement, EzXML.libxml2),
-            Cint,
-            (Ptr{Cvoid},),
-            attrs.reader.ptr)
-        @assert r == 1
+        if nodetype(attrs.reader) == READER_ATTRIBUTE
+            r = ccall(
+                (:xmlTextReaderMoveToElement, EzXML.libxml2),
+                Cint,
+                (Ptr{Cvoid},),
+                attrs.reader.ptr)
+            @assert r == 1
+        end
         return nothing
     end
 end

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -477,7 +477,7 @@ function attribute_ptr(reader::StreamReader, no::Integer)
         (:xmlTextReaderGetAttributeNo, libxml2),
         Cstring,
         (Ptr{Cvoid}, Cint),
-        reader.ptr, Cint(no))
+        reader.ptr, Cint(no - 1))
 end
 
 """

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -435,11 +435,11 @@ Return an AttributeReader for the current node of `reader`
 eachattribute(reader::StreamReader) = AttributeReader(reader)
 
 """
-    nodeattributecount(reader::StreamReader)
+    countattributes(reader::StreamReader)
 
 Return the number of attributes in the current node of `reader`.
 """
-function nodeattributecount(reader::StreamReader)
+function countattributes(reader::StreamReader)
     r = ccall(
         (:xmlTextReaderAttributeCount, EzXML.libxml2),
         Cint,

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -368,7 +368,7 @@ function nodevalue(reader::StreamReader)
         (Ptr{Cvoid},),
         reader.ptr)
     if value_ptr == C_NULL
-        throw(ArgumentError("Node does not have a value"))
+        throw(ArgumentError("no node value"))
     else
         return unsafe_string(value_ptr)
     end

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -428,9 +428,9 @@ function Base.iterate(attrs::AttributeReader, state = nothing)
 end
 
 """
-    nodeattributecount(reader::StreamReader)
+    eachattribute(reader::StreamReader)
 
-Return a AttributeReader for the current node of `reader`
+Return an AttributeReader for the current node of `reader`
 """
 eachattribute(reader::StreamReader) = AttributeReader(reader)
 

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -471,7 +471,7 @@ end
 
 function _getattr(reader::StreamReader, no::Integer)
     value_ptr = ccall(
-        (:xmlTextReaderGetAttribute, libxml2),
+        (:xmlTextReaderGetAttributeNo, libxml2),
         Cstring,
         (Ptr{Cvoid}, Cint),
         reader.ptr, Cint(no))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -410,7 +410,7 @@ end
                         @test nodevalue(attr) == "This is cool"
                     end
                 end
-            elseif EzXML.nodename(reader) == "b"
+            elseif nodename(reader) == "b"
                 @test !hasnodeattributes(reader)
                 @test nodeattributes(reader) == Dict{String,String}()
                 @test countattributes(reader) == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -379,6 +379,38 @@ end
     end
     @test true
 
+    reader = EzXML.StreamReader(IOBuffer("""
+    <a attr1="" attr2="This is cool">
+        <b/>
+    </a>
+    """))
+    for typ in reader
+        if typ == EzXML.READER_ELEMENT
+            if EzXML.nodename(reader) == "a"
+                @test EzXML.hasnodeattributes(reader)
+                @test EzXML.nodeattributecount(reader) == 2
+                @test EzXML.nodeattributes(reader) == Dict{String,String}("attr1"=>"", "attr2"=>"This is cool")
+                for (i,attr) in enumerate(EzXML.eachattribute(reader))
+                    @test EzXML.hasnodevalue(attr)
+                    @test EzXML.nodedepth(attr) == 1
+                    if i == 1
+                        @test EzXML.nodename(attr) == "attr1"
+                        @test EzXML.nodevalue(attr) == ""
+                    else
+                        @test EzXML.nodename(attr) == "attr2"
+                        @test EzXML.nodevalue(attr) == "This is cool"
+                    end
+                end
+            elseif EzXML.nodename(reader) == "b"
+                @test !EzXML.hasnodeattributes(reader)
+                @test EzXML.nodeattributes(reader) == Dict{String,String}()
+                @test EzXML.nodeattributecount(reader) == 0
+            end
+        end
+    end
+    close(reader)
+
+
     # memory management test (XPath)
     # FIXME: support XPath
     #for _ in 1:10

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,12 +234,35 @@ end
 end
 
 @testset "Stream Reader" begin
+    readertypeSymbol = Dict{EzXML.ReaderType, Symbol}(
+        EzXML.READER_NONE => :READER_NONE,
+        EzXML.READER_ELEMENT => :READER_ELEMENT,
+        EzXML.READER_ATTRIBUTE => :READER_ATTRIBUTE,
+        EzXML.READER_TEXT => :READER_TEXT,
+        EzXML.READER_CDATA => :READER_CDATA,
+        EzXML.READER_ENTITY_REFERENCE => :READER_ENTITY_REFERENCE,
+        EzXML.READER_ENTITY => :READER_ENTITY,
+        EzXML.READER_PROCESSING_INSTRUCTION => :READER_PROCESSING_INSTRUCTION,
+        EzXML.READER_COMMENT => :READER_COMMENT,
+        EzXML.READER_DOCUMENT => :READER_DOCUMENT,
+        EzXML.READER_DOCUMENT_TYPE => :READER_DOCUMENT_TYPE,
+        EzXML.READER_DOCUMENT_FRAGMENT => :READER_DOCUMENT_FRAGMENT,
+        EzXML.READER_NOTATION => :READER_NOTATION,
+        EzXML.READER_WHITESPACE => :READER_WHITESPACE,
+        EzXML.READER_SIGNIFICANT_WHITESPACE => :READER_SIGNIFICANT_WHITESPACE,
+        EzXML.READER_END_ELEMENT => :READER_END_ELEMENT,
+        EzXML.READER_END_ENTITY => :READER_END_ENTITY,
+        EzXML.READER_XML_DECLARATION => :READER_XML_DECLARATION
+    )
+
     for i in 0:17
         t = convert(EzXML.ReaderType, i)
+
         @test t == i
         @test occursin(r"READER_[A-Z_]+$", repr(t))
         @test string(t) == string(i)
         @test convert(EzXML.ReaderType, t) === t
+        @test  convert(Symbol,t) === readertypeSymbol[t]
     end
     @test_throws AssertionError repr(convert(EzXML.ReaderType, -1))
     @test_throws AssertionError repr(convert(EzXML.ReaderType, 18))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -245,7 +245,6 @@ end
     end
     @test_throws AssertionError repr(convert(EzXML.ReaderType, -1))
     @test_throws AssertionError repr(convert(EzXML.ReaderType, 18))
-    @test_throws AssertionError convert(Symbol, EzXML.ReaderType(18))
 
     sample2 = joinpath(dirname(@__FILE__), "sample2.xml")
     reader = open(EzXML.StreamReader, sample2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,26 +234,6 @@ end
 end
 
 @testset "Stream Reader" begin
-    readertypeSymbol = Dict{EzXML.ReaderType, Symbol}(
-        EzXML.READER_NONE => :READER_NONE,
-        EzXML.READER_ELEMENT => :READER_ELEMENT,
-        EzXML.READER_ATTRIBUTE => :READER_ATTRIBUTE,
-        EzXML.READER_TEXT => :READER_TEXT,
-        EzXML.READER_CDATA => :READER_CDATA,
-        EzXML.READER_ENTITY_REFERENCE => :READER_ENTITY_REFERENCE,
-        EzXML.READER_ENTITY => :READER_ENTITY,
-        EzXML.READER_PROCESSING_INSTRUCTION => :READER_PROCESSING_INSTRUCTION,
-        EzXML.READER_COMMENT => :READER_COMMENT,
-        EzXML.READER_DOCUMENT => :READER_DOCUMENT,
-        EzXML.READER_DOCUMENT_TYPE => :READER_DOCUMENT_TYPE,
-        EzXML.READER_DOCUMENT_FRAGMENT => :READER_DOCUMENT_FRAGMENT,
-        EzXML.READER_NOTATION => :READER_NOTATION,
-        EzXML.READER_WHITESPACE => :READER_WHITESPACE,
-        EzXML.READER_SIGNIFICANT_WHITESPACE => :READER_SIGNIFICANT_WHITESPACE,
-        EzXML.READER_END_ELEMENT => :READER_END_ELEMENT,
-        EzXML.READER_END_ENTITY => :READER_END_ENTITY,
-        EzXML.READER_XML_DECLARATION => :READER_XML_DECLARATION
-    )
 
     for i in 0:17
         t = convert(EzXML.ReaderType, i)
@@ -262,7 +242,6 @@ end
         @test occursin(r"READER_[A-Z_]+$", repr(t))
         @test string(t) == string(i)
         @test convert(EzXML.ReaderType, t) === t
-        @test  convert(Symbol,t) === readertypeSymbol[t]
     end
     @test_throws AssertionError repr(convert(EzXML.ReaderType, -1))
     @test_throws AssertionError repr(convert(EzXML.ReaderType, 18))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,10 +234,8 @@ end
 end
 
 @testset "Stream Reader" begin
-
     for i in 0:17
         t = convert(EzXML.ReaderType, i)
-
         @test t == i
         @test occursin(r"READER_[A-Z_]+$", repr(t))
         @test string(t) == string(i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -410,34 +410,34 @@ end
     """))
     for typ in reader
         if typ == EzXML.READER_ELEMENT
-            if EzXML.nodename(reader) == "a"
-                @test !EzXML.hasnodevalue(reader)
-                @test EzXML.nodevalue(reader) === nothing
-                @test EzXML.hasnodeattributes(reader)
-                @test EzXML.nodeattributecount(reader) == 2
-                @test EzXML.nodeattributes(reader) == Dict{String,String}("attr1"=>"", "attr2"=>"This is cool")
+            if nodename(reader) == "a"
+                @test !hasnodevalue(reader)
+                @test_throws ArgumentError nodevalue(reader)
+                @test hasnodeattributes(reader)
+                @test countattributes(reader) == 2
+                @test nodeattributes(reader) == Dict{String,String}("attr1"=>"", "attr2"=>"This is cool")
                 @test reader[0] == ""
                 @test reader[1] == "This is cool"
                 @test_throws KeyError reader[2]
                 @test_throws KeyError reader["noattr"]
-                for (i,attr) in enumerate(EzXML.eachattribute(reader))
-                    @test EzXML.hasnodevalue(attr)
-                    @test EzXML.nodedepth(attr) == 1
+                for (i,attr) in enumerate(eachattribute(reader))
+                    @test hasnodevalue(attr)
+                    @test nodedepth(attr) == 1
                     if i == 1
-                        @test EzXML.nodename(attr) == "attr1"
-                        @test EzXML.nodevalue(attr) == ""
+                        @test nodename(attr) == "attr1"
+                        @test nodevalue(attr) == ""
                     else
-                        @test EzXML.nodename(attr) == "attr2"
-                        @test EzXML.nodevalue(attr) == "This is cool"
+                        @test nodename(attr) == "attr2"
+                        @test nodevalue(attr) == "This is cool"
                     end
                 end
             elseif EzXML.nodename(reader) == "b"
-                @test !EzXML.hasnodeattributes(reader)
-                @test EzXML.nodeattributes(reader) == Dict{String,String}()
-                @test EzXML.nodeattributecount(reader) == 0
+                @test !hasnodeattributes(reader)
+                @test nodeattributes(reader) == Dict{String,String}()
+                @test countattributes(reader) == 0
             end
         elseif typ == EzXML.READER_END_ELEMENT
-            @test_throws InvalidStateException EzXML.eachattribute(reader)
+            @test_throws ArgumentError eachattribute(reader)
         end
     end
     close(reader)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -416,9 +416,9 @@ end
                 @test hasnodeattributes(reader)
                 @test countattributes(reader) == 2
                 @test nodeattributes(reader) == Dict{String,String}("attr1"=>"", "attr2"=>"This is cool")
-                @test reader[0] == ""
-                @test reader[1] == "This is cool"
-                @test_throws KeyError reader[2]
+                @test reader[1] == ""
+                @test reader[2] == "This is cool"
+                @test_throws KeyError reader[3]
                 @test_throws KeyError reader["noattr"]
                 for (i,attr) in enumerate(eachattribute(reader))
                     @test hasnodevalue(attr)


### PR DESCRIPTION
Adds functions for accessing attributes with the StreamReader without having to expand the tree.

Features:
- Getting Values from the XML Events (Attributes don't have content, they have values)
  - hasnodevalue
  - nodevalue
- Getting Attributes with "name" or numeric index
- Getting a Julia Dictionary of the attribute names and values
- Added AttributeReader Iterator
- Get Number of Attributes
- Check if Attributes Exist

Todo:

- [x] Add Documentation

