### PR TITLE
use references instead of pointers to pass I/O objects to C callback

### DIFF
--- a/src/document.jl
+++ b/src/document.jl
@@ -210,8 +210,8 @@ end
 function make_read_callback()
     # Passing an input stream as an argument is impossible to create a callback
     # because Julia does not support C-callable closures yet.
-    return @cfunction(Cint, (Ptr{Cvoid}, Ptr{UInt8}, Cint)) do context, buffer, len
-        input = unsafe_pointer_to_objref(context)
+    return @cfunction(Cint, (Ref{IO}, Ptr{UInt8}, Cint)) do context, buffer, len
+        input = context
         avail = min(bytesavailable(input), len)
         if avail > 0
             unsafe_read(input, buffer, avail)
@@ -229,6 +229,7 @@ function make_read_callback()
         return Cint(read)
     end
 end
+
 
 # Properties
 # ----------

--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -138,14 +138,14 @@ end
 function StreamReader(input::IO)
     readcb = make_read_callback()
     closecb = C_NULL
-    context = pointer_from_objref(input)
+    context = input
     uri = C_NULL
     encoding = C_NULL
     options = 0
     reader_ptr = @check ccall(
         (:xmlReaderForIO, libxml2),
         Ptr{_TextReader},
-        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Cstring, Cstring, Cint),
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ref{IO}, Cstring, Cstring, Cint),
         readcb, closecb, context, uri, encoding, options) != C_NULL
     return StreamReader(reader_ptr, input)
 end


### PR DESCRIPTION
This addresses https://github.com/bicycle1885/TranscodingStreams.jl/issues/66.
Passing objects to callbacks is hacky and an old-fashioned workaround in the era of Julia 1.0.
With this change, the code like below works as expected:
```julia
using EzXML
using CodecZlib

reader = EzXML.StreamReader(GzipDecompressorStream(open("test/sample1.xml.gz")))
for t in reader end
close(reader)
```

Maybe needs some tests.