### PR TITLE
Use getfield instead of getproperty for performance

### DIFF
--- a/src/streamreader.jl
+++ b/src/streamreader.jl
@@ -195,7 +195,7 @@ function read_node(reader)
         (:xmlTextReaderRead, libxml2),
         Cint,
         (Ptr{Cvoid},),
-        reader.ptr) ≥ 0
+        getfield(reader, :ptr)) ≥ 0
     return ret == 0
 end
 
@@ -209,7 +209,7 @@ function nodedepth(reader::StreamReader)
         (:xmlTextReaderDepth, libxml2),
         Cint,
         (Ptr{Cvoid},),
-        reader.ptr)
+        getfield(reader, :ptr))
     return Int(ret)
 end
 
@@ -223,7 +223,7 @@ function nodetype(reader::StreamReader)
         (:xmlTextReaderNodeType, libxml2),
         Cint,
         (Ptr{Cvoid},),
-        reader.ptr)
+        getfield(reader, :ptr))
     return convert(ReaderType, typ)
 end
 
@@ -237,7 +237,7 @@ function hasnodename(reader::StreamReader)
         (:xmlTextReaderConstName, libxml2),
         Cstring,
         (Ptr{Cvoid},),
-        reader.ptr) != C_NULL
+        getfield(reader, :ptr)) != C_NULL
 end
 
 """
@@ -250,7 +250,7 @@ function nodename(reader::StreamReader)
         (:xmlTextReaderConstName, libxml2),
         Cstring,
         (Ptr{Cvoid},),
-        reader.ptr)
+        getfield(reader, :ptr))
     if name_ptr == C_NULL
         throw(ArgumentError("no node name"))
     end
@@ -271,7 +271,7 @@ function hasnodecontent(reader::StreamReader)
         (:xmlTextReaderReadString, libxml2),
         Cstring,
         (Ptr{Cvoid},),
-        reader.ptr)
+        getfield(reader, :ptr))
     if ptr == C_NULL
         return false
     else
@@ -293,7 +293,7 @@ function nodecontent(reader::StreamReader)
         (:xmlTextReaderReadString, libxml2),
         Cstring,
         (Ptr{Cvoid},),
-        reader.ptr)
+        getfield(reader, :ptr))
     if content_ptr == C_NULL
         throw(ArgumentError("no content"))
     end
@@ -312,7 +312,7 @@ function hasnodevalue(reader::StreamReader)
        (:xmlTextReaderHasValue, libxml2),
        Cint,
        (Ptr{Cvoid},),
-       reader.ptr)
+       getfield(reader, :ptr))
     return r == 1
 end
 
@@ -328,7 +328,7 @@ function nodevalue(reader::StreamReader)
         (:xmlTextReaderConstValue, libxml2),
         Cstring,
         (Ptr{Cvoid},),
-        reader.ptr)
+        getfield(reader, :ptr))
     if value_ptr == C_NULL
         throw(ArgumentError("no node value"))
     end
@@ -345,7 +345,7 @@ function hasnodeattributes(reader::StreamReader)
        (:xmlTextReaderHasAttributes, libxml2),
        Cint,
        (Ptr{Cvoid},),
-       reader.ptr)
+       getfield(reader, :ptr))
     @assert r ≥ 0 "XML Error Detected"
     return r == 1
 end
@@ -374,7 +374,7 @@ function Base.iterate(attrs::AttributeReader, state=nothing)
         (:xmlTextReaderMoveToNextAttribute, libxml2),
         Cint,
         (Ptr{Cvoid},),
-        attrs.reader.ptr)
+        getfield(attrs.reader, :ptr))
     if r == 1
         return attrs.reader, nothing
     end
@@ -383,7 +383,7 @@ function Base.iterate(attrs::AttributeReader, state=nothing)
             (:xmlTextReaderMoveToElement, libxml2),
             Cint,
             (Ptr{Cvoid},),
-            attrs.reader.ptr)
+            getfield(attrs.reader, :ptr))
         @assert r == 1
     end
     return nothing
@@ -406,7 +406,7 @@ function countattributes(reader::StreamReader)
         (:xmlTextReaderAttributeCount, libxml2),
         Cint,
         (Ptr{Cvoid},),
-        reader.ptr)
+        getfield(reader, :ptr))
     return Int(r)
 end
 
@@ -428,7 +428,7 @@ function attribute_ptr(reader::StreamReader, name::AbstractString)
         (:xmlTextReaderGetAttribute, libxml2),
         Cstring,
         (Ptr{Cvoid}, Cstring),
-        reader.ptr, name)
+        getfield(reader, :ptr), name)
 end
 
 function attribute_ptr(reader::StreamReader, no::Integer)
@@ -436,7 +436,7 @@ function attribute_ptr(reader::StreamReader, no::Integer)
         (:xmlTextReaderGetAttributeNo, libxml2),
         Cstring,
         (Ptr{Cvoid}, Cint),
-        reader.ptr, Cint(no - 1))
+        getfield(reader, :ptr), Cint(no - 1))
 end
 
 """
@@ -476,7 +476,7 @@ function namespace(reader::StreamReader)
         (:xmlTextReaderConstNamespaceUri, libxml2),
         Cstring,
         (Ptr{Cvoid},),
-        reader.ptr)
+        getfield(reader, :ptr))
     if ns_ptr == C_NULL
         throw(ArgumentError("no namespace"))
     end
@@ -500,7 +500,7 @@ function expandtree(reader::StreamReader)
         (:xmlTextReaderExpand, libxml2),
         Ptr{_Node},
         (Ptr{Cvoid},),
-        reader.ptr) != C_NULL
+        getfield(reader, :ptr)) != C_NULL
     # do not automatically free memories
     return Node(node_ptr, false)
 end


### PR DESCRIPTION
This fixes #139.

For some unknown reason, Julia seems to fail to inline `getproperty` of `StreamReader`, which causes significant performance degradation as reported in #139.

This change works around the problem by directly calling `getfield(reader, :ptr)` in some performance-critical functions. The performance improvement was ~20% in `uniprot_sprot.xml.gz` downloaded from https://www.uniprot.org/downloads.

```julia
using EzXML
using Printf

function scan(filepath)
    s = time()
    n = 0
    open(EzXML.StreamReader, filepath) do reader
        for node in reader
            n += 1
            if n % (1 << 20) == 0
                t = time() - s
                @printf "%10d nodes - %.1fk nodes/sec\n" n (n / t / 1000)
                if t > 5
                    break
                end
            end
        end
    end
    return n
end

for _ in 1:3
    scan("uniprot_sprot.xml.gz")
end
```

Before:
```
   1048576 nodes - 1542.3k nodes/sec
   2097152 nodes - 1588.9k nodes/sec
   3145728 nodes - 1620.1k nodes/sec
   4194304 nodes - 1659.2k nodes/sec
   5242880 nodes - 1705.0k nodes/sec
   6291456 nodes - 1739.3k nodes/sec
   7340032 nodes - 1768.2k nodes/sec
   8388608 nodes - 1786.7k nodes/sec
   9437184 nodes - 1800.8k nodes/sec
   1048576 nodes - 1941.0k nodes/sec
   2097152 nodes - 1935.6k nodes/sec
   3145728 nodes - 1932.0k nodes/sec
   4194304 nodes - 1928.1k nodes/sec
   5242880 nodes - 1928.4k nodes/sec
   6291456 nodes - 1929.7k nodes/sec
   7340032 nodes - 1936.2k nodes/sec
   8388608 nodes - 1938.6k nodes/sec
   9437184 nodes - 1937.2k nodes/sec
  10485760 nodes - 1939.2k nodes/sec
   1048576 nodes - 1950.4k nodes/sec
   2097152 nodes - 1947.5k nodes/sec
   3145728 nodes - 1935.5k nodes/sec
   4194304 nodes - 1930.1k nodes/sec
   5242880 nodes - 1928.0k nodes/sec
   6291456 nodes - 1928.6k nodes/sec
   7340032 nodes - 1934.5k nodes/sec
   8388608 nodes - 1934.9k nodes/sec
   9437184 nodes - 1934.0k nodes/sec
  10485760 nodes - 1935.9k nodes/sec
```

After:
```
   1048576 nodes - 2111.7k nodes/sec
   2097152 nodes - 2077.4k nodes/sec
   3145728 nodes - 2176.8k nodes/sec
   4194304 nodes - 2243.5k nodes/sec
   5242880 nodes - 2280.7k nodes/sec
   6291456 nodes - 2309.4k nodes/sec
   7340032 nodes - 2319.1k nodes/sec
   8388608 nodes - 2339.3k nodes/sec
   9437184 nodes - 2352.7k nodes/sec
  10485760 nodes - 2366.4k nodes/sec
  11534336 nodes - 2375.7k nodes/sec
  12582912 nodes - 2381.3k nodes/sec
   1048576 nodes - 2459.0k nodes/sec
   2097152 nodes - 2470.2k nodes/sec
   3145728 nodes - 2468.4k nodes/sec
   4194304 nodes - 2466.8k nodes/sec
   5242880 nodes - 2465.2k nodes/sec
   6291456 nodes - 2465.9k nodes/sec
   7340032 nodes - 2474.2k nodes/sec
   8388608 nodes - 2477.2k nodes/sec
   9437184 nodes - 2467.1k nodes/sec
  10485760 nodes - 2470.8k nodes/sec
  11534336 nodes - 2471.1k nodes/sec
  12582912 nodes - 2470.6k nodes/sec
   1048576 nodes - 2488.9k nodes/sec
   2097152 nodes - 2481.8k nodes/sec
   3145728 nodes - 2472.1k nodes/sec
   4194304 nodes - 2468.2k nodes/sec
   5242880 nodes - 2462.9k nodes/sec
   6291456 nodes - 2466.1k nodes/sec
   7340032 nodes - 2472.9k nodes/sec
   8388608 nodes - 2475.4k nodes/sec
   9437184 nodes - 2474.2k nodes/sec
  10485760 nodes - 2474.1k nodes/sec
  11534336 nodes - 2472.8k nodes/sec
  12582912 nodes - 2470.5k nodes/sec
```

Versioninfo:
```
julia> versioninfo()
Julia Version 1.4.1
Commit 381693d3df* (2020-04-14 17:20 UTC)
Platform Info:
  OS: Linux (x86_64-pc-linux-gnu)
  CPU: AMD Ryzen 5 2400G with Radeon Vega Graphics
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-8.0.1 (ORCJIT, znver1)
Environment:
  JULIA_PROJECT = @.
```